### PR TITLE
Exclude detached configurations from dependency graph

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,6 +34,7 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
       with:
         dependency-graph: generate-and-submit
+        dependency-graph-exclude-configurations: 'detachedConfiguration.*'
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build


### PR DESCRIPTION
This ought to negate the security vulnerability reports.