### PR TITLE
Set parallelism in Kotest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX\:+UseParallelGC
 org.gradle.configuration-cache=true
+kotest.framework.parallelism=4


### PR DESCRIPTION
Another possible way to speed up the build - add parallelism to the unit tests.