### PR TITLE
Load Java agent statically for Mockk DSL dependency

### DIFF
--- a/IAN/build.gradle.kts
+++ b/IAN/build.gradle.kts
@@ -26,8 +26,16 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
+val byteBuddyAgent: Configuration by configurations.creating
+
 tasks.test {
-    jvmArgs("-Xmx2g", "-Xms1g", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UseParallelGC")
+    jvmArgs(
+        "-Xmx2g",
+        "-Xms1g",
+        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-XX:+UseParallelGC",
+        "-javaagent:${byteBuddyAgent.asPath}",
+    )
     useJUnitPlatform()
 }
 
@@ -72,6 +80,8 @@ dependencies {
     testImplementation(testFixtures(projects.ian.util))
     testImplementation(libs.bundles.ian.test)
     testRuntimeOnly(libs.bundles.ian.test.runtime)
+
+    byteBuddyAgent(libs.byte.buddy.agent)
 
     pitest(libs.bundles.arcmutate)
 }

--- a/IAN/listener/build.gradle.kts
+++ b/IAN/listener/build.gradle.kts
@@ -29,8 +29,16 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
+val byteBuddyAgent: Configuration by configurations.creating
+
 tasks.test {
-    jvmArgs("-Xmx2g", "-Xms1g", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UseParallelGC")
+    jvmArgs(
+        "-Xmx2g",
+        "-Xms1g",
+        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-XX:+UseParallelGC",
+        "-javaagent:${byteBuddyAgent.asPath}",
+    )
     useJUnitPlatform()
 }
 
@@ -47,6 +55,8 @@ dependencies {
     testImplementation(libs.bundles.ian.listener.test)
     testFixturesImplementation(libs.kotlin.reflect)
     testRuntimeOnly(libs.bundles.ian.test.runtime)
+
+    byteBuddyAgent(libs.byte.buddy.agent)
 
     pitest(libs.bundles.arcmutate)
 }

--- a/IAN/packets/build.gradle.kts
+++ b/IAN/packets/build.gradle.kts
@@ -30,8 +30,16 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
+val byteBuddyAgent: Configuration by configurations.creating
+
 tasks.test {
-    jvmArgs("-Xmx4g", "-Xms1g", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UseParallelGC")
+    jvmArgs(
+        "-Xmx4g",
+        "-Xms1g",
+        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-XX:+UseParallelGC",
+        "-javaagent:${byteBuddyAgent.asPath}",
+    )
     useJUnitPlatform()
 }
 
@@ -77,6 +85,8 @@ dependencies {
     testFixturesImplementation(libs.bundles.ian.packets.test.fixtures)
     testImplementation(libs.bundles.ian.packets.test)
     testRuntimeOnly(libs.bundles.ian.test.runtime)
+
+    byteBuddyAgent(libs.byte.buddy.agent)
 
     pitest(libs.bundles.arcmutate)
 }

--- a/IAN/world/build.gradle.kts
+++ b/IAN/world/build.gradle.kts
@@ -30,8 +30,16 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
+val byteBuddyAgent: Configuration by configurations.creating
+
 tasks.test {
-    jvmArgs("-Xmx2g", "-Xms1g", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UseParallelGC")
+    jvmArgs(
+        "-Xmx2g",
+        "-Xms1g",
+        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-XX:+UseParallelGC",
+        "-javaagent:${byteBuddyAgent.asPath}",
+    )
     useJUnitPlatform()
 }
 
@@ -56,6 +64,8 @@ dependencies {
     testImplementation(testFixtures(projects.ian.vesseldata))
     testImplementation(libs.bundles.ian.world.test)
     testRuntimeOnly(libs.bundles.ian.test.runtime)
+
+    byteBuddyAgent(libs.byte.buddy.agent)
 
     pitest(libs.bundles.arcmutate)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,8 @@ plugins {
     alias(libs.plugins.dependency.analysis)
 }
 
+val byteBuddyAgent: Configuration by configurations.creating
+
 val appName = "Artemis Agent"
 val appId = "artemis.agent"
 val sdkVersion: Int by rootProject.extra
@@ -70,7 +72,10 @@ android {
     }
 
     testOptions.execution = "ANDROIDX_TEST_ORCHESTRATOR"
-    testOptions.unitTests.all { it.useJUnitPlatform() }
+    testOptions.unitTests.all {
+        it.jvmArgs("-javaagent:${byteBuddyAgent.asPath}")
+        it.useJUnitPlatform()
+    }
 
     signingConfigs {
         create(release) {
@@ -135,6 +140,8 @@ dependencies {
 
     testImplementation(libs.bundles.app.test)
     testRuntimeOnly(libs.bundles.app.test.runtime)
+
+    byteBuddyAgent(libs.byte.buddy.agent)
 
     androidTestImplementation(libs.bundles.app.androidTest) {
         exclude(group = "org.hamcrest", module = "hamcrest-core")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ app-review = "2.0.2"
 app-update = "2.1.0"
 arcmutate-base = "1.5.3"
 arcmutate-kotlin = "1.4.3"
+byte-buddy-agent = "1.17.7"
 crashlytics-plugin = "3.0.6"
 dependency-analysis = "3.0.1"
 desugar = "2.1.5"
@@ -173,6 +174,8 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-dsl = { module = "io.mockk:mockk-dsl", version.ref = "mockk" }
+
+byte-buddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "byte-buddy-agent" }
 
 arcmutate-base = { module = "com.arcmutate:base", version.ref = "arcmutate-base" }
 arcmutate-kotlin = { module = "com.arcmutate:pitest-kotlin-plugin", version.ref = "arcmutate-kotlin" }


### PR DESCRIPTION
Currently making MockK fail in some unit tests. Need to investigate.