### PR TITLE
AVD snapshot caching in CI pipeline

### DIFF
--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -52,7 +52,7 @@ jobs:
         uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4
 
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: avd-cache
         with:
           key: avd-${{ matrix.api-level }}-${{ matrix.orientation.name }}


### PR DESCRIPTION
An attempt to make Android emulators boot faster in CI, and hopefully also make the tests more reliable.