### PR TITLE
Use JaCoCo with Kover

### DIFF
--- a/IAN/build.gradle.kts
+++ b/IAN/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 
 configureTests(maxMemoryGb = 8)
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian", threads = 2)
 
 val konsistCollect by tasks.registering {

--- a/IAN/enums/build.gradle.kts
+++ b/IAN/enums/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 configureTests()
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian.enums", threads = 2)
 
 dependsOnKonsist()

--- a/IAN/grid/build.gradle.kts
+++ b/IAN/grid/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 
 configureTests()
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian.grid", threads = 2)
 
 dependencies {

--- a/IAN/listener/build.gradle.kts
+++ b/IAN/listener/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 configureTests()
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian.iface", threads = 2)
 
 dependsOnKonsist()

--- a/IAN/packets/build.gradle.kts
+++ b/IAN/packets/build.gradle.kts
@@ -14,6 +14,8 @@ koinCompiler { userLogs = true }
 
 configureTests(maxMemoryGb = 4)
 
+kover.useJacoco()
+
 pitest {
     configure(rootPackage = "com.walkertribe.ian.protocol", threads = 8)
     jvmArgs = listOf("-Xmx8g", "-Xms1g", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UseParallelGC")

--- a/IAN/udp/build.gradle.kts
+++ b/IAN/udp/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 configureTests()
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian.protocol", threads = 2)
 
 dependsOnKonsist()

--- a/IAN/util/build.gradle.kts
+++ b/IAN/util/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 
 configureTests()
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian.util", threads = 2)
 
 dependencies {

--- a/IAN/vesseldata/build.gradle.kts
+++ b/IAN/vesseldata/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 configureTests()
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian.vesseldata", threads = 2)
 
 dependsOnKonsist()

--- a/IAN/world/build.gradle.kts
+++ b/IAN/world/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 
 configureTests()
 
+kover.useJacoco()
+
 pitest.configure(rootPackage = "com.walkertribe.ian.world", threads = 2)
 
 dependsOnKonsist()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -189,6 +189,8 @@ dependencies {
     lintChecks(libs.lint.security)
 }
 
+kover.useJacoco()
+
 detekt {
     source.from(files("src/androidTest/kotlin"))
     ignoredBuildTypes = listOf(release)


### PR DESCRIPTION
A bit of experimentation/investigative work to find out why Kover is outputting inconsistent coverage reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage instrumentation configuration across build modules to use JaCoCo for consistent coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->