### PR TITLE
Remove Koin

### DIFF
--- a/IAN/packets/build.gradle.kts
+++ b/IAN/packets/build.gradle.kts
@@ -6,11 +6,8 @@ plugins {
     id("ian-library")
     id("fixtures")
     alias(libs.plugins.ksp)
-    alias(libs.plugins.koin)
     id("info.solidsoft.pitest")
 }
-
-koinCompiler { userLogs = true }
 
 configureTests(maxMemoryGb = 4)
 

--- a/IAN/packets/detekt-baseline.xml
+++ b/IAN/packets/detekt-baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>TooManyFunctions:PacketReader.kt$PacketReader : KoinComponent</ID>
+    <ID>TooManyFunctions:PacketReader.kt$PacketReader</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/IAN/packets/src/main/kotlin/com/walkertribe/ian/iface/PacketReader.kt
+++ b/IAN/packets/src/main/kotlin/com/walkertribe/ian/iface/PacketReader.kt
@@ -2,7 +2,7 @@ package com.walkertribe.ian.iface
 
 import com.walkertribe.ian.enums.ObjectType
 import com.walkertribe.ian.enums.Origin
-import com.walkertribe.ian.protocol.IAN
+import com.walkertribe.ian.protocol.ArtemisProtocol
 import com.walkertribe.ian.protocol.Packet
 import com.walkertribe.ian.protocol.PacketException
 import com.walkertribe.ian.protocol.Protocol
@@ -32,10 +32,6 @@ import kotlinx.io.readByteArray
 import kotlinx.io.readFloatLe
 import kotlinx.io.readIntLe
 import kotlinx.io.readShortLe
-import org.koin.core.Koin
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.plugin.module.dsl.koinApplication
 
 /**
  * Facilitates reading packets from an [ByteReadChannel]. This object may be reused to read as many
@@ -47,10 +43,8 @@ import org.koin.plugin.module.dsl.koinApplication
 class PacketReader(
     private val channel: ByteReadChannel,
     private val listenerRegistry: ListenerRegistry,
-) : KoinComponent {
-    private val koinApp = koinApplication<IAN>()
-
-    private val protocol: Protocol by inject()
+) {
+    private val protocol: Protocol = ArtemisProtocol
 
     private val rejectedObjectIDs = mutableSetOf<Int>()
 
@@ -278,7 +272,6 @@ class PacketReader(
 
     fun close(cause: Throwable? = null) {
         channel.cancel(cause)
-        koinApp.close()
     }
 
     /** Removes the given object ID from the set of IDs for which to reject updates. */
@@ -340,6 +333,4 @@ class PacketReader(
 
         return packetType to payloadPacket
     }
-
-    override fun getKoin(): Koin = koinApp.koin
 }

--- a/IAN/packets/src/test/kotlin/com/walkertribe/ian/protocol/ProtocolTest.kt
+++ b/IAN/packets/src/test/kotlin/com/walkertribe/ian/protocol/ProtocolTest.kt
@@ -22,8 +22,6 @@ import com.walkertribe.ian.protocol.core.world.DockedPacket
 import com.walkertribe.ian.protocol.core.world.ObjectUpdatePacket
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
-import io.kotest.koin.KoinExtension
-import io.kotest.koin.KoinLifecycleMode
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -37,16 +35,12 @@ import io.kotest.property.exhaustive.bytes
 import io.kotest.property.exhaustive.filterNot
 import io.kotest.property.exhaustive.of
 import kotlin.reflect.KClass
-import org.koin.test.KoinTest
-import org.koin.test.inject
 
-class ProtocolTest : DescribeSpec(), KoinTest {
-    private val protocol: Protocol by inject()
-
-    init {
-        extension(KoinExtension(ProtocolModule().module(), mode = KoinLifecycleMode.Root))
-
+class ProtocolTest :
+    DescribeSpec({
         describe("Protocol") {
+            val protocol = ArtemisProtocol
+
             describe("Has factories registered for server packets") {
                 data class ServerPacketRegistration(
                     val packetClass: KClass<out Packet>,
@@ -225,5 +219,4 @@ class ProtocolTest : DescribeSpec(), KoinTest {
                 }
             }
         }
-    }
-}
+    })

--- a/IAN/processor/build.gradle.kts
+++ b/IAN/processor/build.gradle.kts
@@ -2,7 +2,6 @@ plugins { id("ian-library") }
 
 dependencies {
     api(libs.kotlin.stdlib)
-    api(libs.koin.annotations)
     api(libs.ksp.api)
     api(libs.kotlinpoet)
 

--- a/IAN/processor/src/main/kotlin/com/walkertribe/ian/ksp/PacketProcessor.kt
+++ b/IAN/processor/src/main/kotlin/com/walkertribe/ian/ksp/PacketProcessor.kt
@@ -24,11 +24,6 @@ import com.walkertribe.ian.protocol.PacketType
 import com.walkertribe.ian.util.JamCrc
 import com.walkertribe.ian.util.Util.toHex
 import kotlin.reflect.KClass
-import org.koin.core.annotation.ComponentScan
-import org.koin.core.annotation.Configuration
-import org.koin.core.annotation.KoinApplication
-import org.koin.core.annotation.Module
-import org.koin.core.annotation.Single
 
 class PacketProcessor(private val codeGenerator: CodeGenerator) : SymbolProcessor {
     private val visitor: PacketVisitor by lazy { PacketVisitor(codeGenerator) }
@@ -68,28 +63,25 @@ class PacketProcessor(private val codeGenerator: CodeGenerator) : SymbolProcesso
 
         val getFactoryFunBuilder = makeFactoryFunBuilder(abstractSymbols)
 
-        val protocolCompanionBuilder = makeCompanionBuilder(symbols, subtypeMap)
-
-        val protocolClassBuilder =
-            TypeSpec.classBuilder(FILENAME)
+        val protocolObjectBuilder =
+            TypeSpec.objectBuilder(FILENAME)
                 .addSuperinterface(ClassName(MAIN_PACKAGE, "Protocol"))
-                .addAnnotation(Single::class)
                 .addFunction(getFactoryFunBuilder.build())
-                .addType(protocolCompanionBuilder.build())
+                .addSymbolProperties("", symbols, "%L") { it.toString() }
 
-        val protocolModuleBuilder =
-            TypeSpec.classBuilder("ProtocolModule")
-                .addAnnotation(Module::class)
-                .addAnnotation(ComponentScan::class)
-                .addAnnotation(Configuration::class)
+        subtypeMap.forEach { (parentName, subtypeClasses) ->
+            protocolObjectBuilder.addSymbolProperties(
+                makeConstantName(parentName) + "_",
+                subtypeClasses
+                    .associateBy { it.getAnnotationsByType(PacketSubtype::class).first().subtype }
+                    .toSortedMap(),
+                "0x%L",
+            ) {
+                it.toHex()
+            }
+        }
 
-        val protocolApplicationBuilder =
-            TypeSpec.objectBuilder("IAN").addAnnotation(KoinApplication::class)
-
-        fileSpecBuilder.addType(protocolClassBuilder.build())
-        fileSpecBuilder.addType(protocolModuleBuilder.build())
-        fileSpecBuilder.addType(protocolApplicationBuilder.build())
-
+        fileSpecBuilder.addType(protocolObjectBuilder.build())
         fileSpecBuilder.build().writeTo(codeGenerator = codeGenerator, aggregating = false)
 
         return emptyList()
@@ -97,7 +89,7 @@ class PacketProcessor(private val codeGenerator: CodeGenerator) : SymbolProcesso
 
     internal companion object {
         const val MAIN_PACKAGE = "com.walkertribe.ian.protocol"
-        const val FILENAME = "KoinProtocol"
+        const val FILENAME = "ArtemisProtocol"
         private const val PACKET_LENGTH = 6
         private const val FACTORY_LENGTH = 7
 
@@ -155,33 +147,6 @@ class PacketProcessor(private val codeGenerator: CodeGenerator) : SymbolProcesso
             }
 
             return factoryFunBuilder.addStatement("else -> FACTORY_MAP[type]").endControlFlow()
-        }
-
-        @OptIn(KspExperimental::class)
-        private fun makeCompanionBuilder(
-            mainPacketClasses: Map<Int, KSClassDeclaration>,
-            subtypePacketClasses: Map<String, List<KSClassDeclaration>>,
-        ): TypeSpec.Builder {
-            val protocolCompanionBuilder =
-                TypeSpec.companionObjectBuilder()
-                    .addModifiers(KModifier.PRIVATE)
-                    .addSymbolProperties("", mainPacketClasses, "%L") { it.toString() }
-
-            subtypePacketClasses.forEach { (parentName, subtypeClasses) ->
-                protocolCompanionBuilder.addSymbolProperties(
-                    makeConstantName(parentName) + "_",
-                    subtypeClasses
-                        .associateBy {
-                            it.getAnnotationsByType(PacketSubtype::class).first().subtype
-                        }
-                        .toSortedMap(),
-                    "0x%L",
-                ) {
-                    it.toHex()
-                }
-            }
-
-            return protocolCompanionBuilder
         }
 
         private inline fun <reified N : Number> TypeSpec.Builder.addSymbolProperties(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,8 +35,6 @@ jspecify = "1.0.0"
 junit4 = "4.13.2"
 kakao = "3.7.0"
 kaspresso = "1.6.1"
-koin = "4.2.1"
-koin-plugin = "1.0.0-RC2"
 konnection = "1.4.5"
 konsist = "0.17.3"
 korlibs-serialization = "6.0.1"
@@ -83,10 +81,6 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",
 kotlinx-coroutines-play = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlin-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlin-io" }
-
-koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koin" }
-koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
-koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
@@ -171,7 +165,6 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core" }
 kotest-assertions-shared = { module = "io.kotest:kotest-assertions-shared" }
 kotest-bom = { module = "io.kotest:kotest-bom", version.ref = "kotest" }
 kotest-common = { module = "io.kotest:kotest-common" }
-kotest-extensions-koin = { module = "io.kotest:kotest-extensions-koin" }
 kotest-extensions-pitest = { module = "io.kotest:kotest-extensions-pitest" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine" }
 kotest-property = { module = "io.kotest:kotest-property" }
@@ -346,8 +339,6 @@ ian-listener-test = [
 ian-packets-api = [
     "kotlin-stdlib",
     "kotlinx-coroutines",
-    "koin-annotations",
-    "koin-core",
     "korlibs-string",
     "ktor-io",
 ]
@@ -355,10 +346,8 @@ ian-packets-test = [
     "kotest-assertions-core",
     "kotest-assertions-shared",
     "kotest-common",
-    "kotest-extensions-koin",
     "kotest-framework-engine",
     "kotest-property",
-    "koin-test",
     "mockk",
     "mockk-core",
     "mockk-dsl",
@@ -491,7 +480,6 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "perf-plugin" }
 git-hooks = { id = "com.github.jakemarsden.git-hooks", version.ref = "git-hooks" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
-koin = { id = "io.insert-koin.compiler.plugin", version.ref = "koin-plugin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
After testing a Detekt rules library designed for Koin applications, I deemed Koin to be unnecessary. The generated protocol is static enough as it is, so I converted it from a class into an object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined internal dependency structure and removed unused framework integration from core modules.
  * Refactored protocol initialization, configuration, and packet handling logic for improved code clarity and maintainability.
  * Updated build tooling, test infrastructure, and dependency declarations across all modules to ensure consistency.
  * Enhanced code generation to reduce framework overhead and overall system complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->